### PR TITLE
fix count

### DIFF
--- a/cmb/init.php
+++ b/cmb/init.php
@@ -743,7 +743,7 @@ class cmb_Meta_Box {
 		elseif ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] ) === 1 )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
I was getting the following warning message:
```
<b>Warning</b>:  count(): Parameter must be an array or an object that implements Countable in <b>/var/www/html/wp-content/themes/fitcoach/cmb/init.php</b> on line <b>746</b><br />
```